### PR TITLE
Switch backend security config to WebFlux

### DIFF
--- a/backend/src/main/java/edu/university/promptlab/config/SecurityConfig.java
+++ b/backend/src/main/java/edu/university/promptlab/config/SecurityConfig.java
@@ -5,23 +5,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 
 @Configuration
 @EnableMethodSecurity
+@EnableWebFluxSecurity
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .cors(Customizer.withDefaults())
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
-                .anyRequest().authenticated()
+            .authorizeExchange(exchanges -> exchanges
+                .pathMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+                .anyExchange().authenticated()
             )
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+            .oauth2ResourceServer(ServerHttpSecurity.OAuth2ResourceServerSpec::jwt);
         return http.build();
     }
 }


### PR DESCRIPTION
## Summary
- replace the servlet SecurityFilterChain with a reactive SecurityWebFilterChain bean
- enable WebFlux security configuration and migrate HTTP security rules to WebFlux APIs

## Testing
- not run (Gradle wrapper ./gradlew not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68ce83960210832d8eb26958038e477d