### PR TITLE
Use reactive CORS configuration source

### DIFF
--- a/backend/src/main/java/edu/university/promptlab/config/WebConfig.java
+++ b/backend/src/main/java/edu/university/promptlab/config/WebConfig.java
@@ -4,8 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 


### PR DESCRIPTION
## Summary
- replace the servlet-based CORS configuration imports in WebConfig with their reactive counterparts so the bean no longer depends on servlet APIs

## Testing
- gradle bootRun *(fails: missing com.google.api.client.json.jackson2.JacksonFactory dependency in SheetsConfig)*

------
https://chatgpt.com/codex/tasks/task_e_68ce88c175a8832d855b32f674162770