### PR TITLE
Add timeout enforcement for Gemini client

### DIFF
--- a/backend/src/main/java/edu/university/promptlab/service/GeminiClient.java
+++ b/backend/src/main/java/edu/university/promptlab/service/GeminiClient.java
@@ -46,6 +46,7 @@ public class GeminiClient {
                 .bodyValue(requestBody)
                 .retrieve()
                 .bodyToMono(Map.class)
+                .timeout(Duration.ofSeconds(30))
                 .onErrorResume(err -> {
                     log.error("Gemini request failed", err);
                     return Mono.just(Map.of());

--- a/backend/src/test/java/edu/university/promptlab/service/GeminiClientTest.java
+++ b/backend/src/test/java/edu/university/promptlab/service/GeminiClientTest.java
@@ -1,0 +1,24 @@
+package edu.university.promptlab.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+class GeminiClientTest {
+
+    @Test
+    void generateTextTimesOutAndReturnsEmptyResponse() {
+        WebClient webClient = WebClient.builder()
+                .exchangeFunction(clientRequest -> Mono.never())
+                .build();
+        GeminiClient client = new GeminiClient(webClient, "test-key", "test-model");
+
+        StepVerifier.withVirtualTime(() -> client.generateText("prompt"))
+                .thenAwait(Duration.ofSeconds(30))
+                .expectNextMatches(response -> response.text().isEmpty() && response.tokens() == null)
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- add a reactive 30-second timeout to GeminiClient generateText before error handling
- add a unit test that simulates a stalled Gemini response and verifies the empty fallback

## Testing
- gradle test *(fails: backend/src/main/java/edu/university/promptlab/config/SheetsConfig.java:5: error: package com.google.api.client.json.jackson2 does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ce94612ed0832db9c9fa8f5fc5bf39